### PR TITLE
Missing posts in front page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,7 @@
 name: Twister
 description: a powerful jekyll theme
 url: #place url
+gems: [jekyll-paginate]
 baseurl: #place folder name if site is served in subfolder
 permalink: /:title/
 paginate: 8


### PR DESCRIPTION
Jekyll Paginator is now a dependency with the latest version of Jekyll,
so posts did not show in the front page.

The documentation should be updated accordingly to instruct users to install Jekyll Paginator.
