### PR TITLE
Remove  @extend from @media block

### DIFF
--- a/sass/partials/components/_authorbox.scss
+++ b/sass/partials/components/_authorbox.scss
@@ -18,7 +18,9 @@ $authorbox_collapse: 510px;
         }
 
         @media screen and (max-width: $authorbox_collapse){
-            @extend %center;
+            display: block;
+            position: relative;
+            margin: 0px auto;
             padding-right: 0;
         }
     }


### PR DESCRIPTION
issue  #9
You may not @extend an outer selector from within @media.