### PR TITLE
Fix pagination for page 1

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,7 +33,12 @@ description: the good site of life
             {% if i == paginator.page %}
                 <span class="disabled">{{ i }}</span>
             {% else %}
-                <a href="/page/{{ i }}">{{ i }}</a>
+                <!-- page/1 will render 404, so redirect to index.html-->
+                {% if i == 1 %}
+                    <a href="{{ '/' | prepend: site.baseurl | replace: '//', '/' }}">{{ i }}</a>
+                {% else %}
+                    <a href="/page/{{ i }}">{{ i }}</a>
+                {% endif %}
             {% endif %}
         {% endfor %}
 


### PR DESCRIPTION
**Issue**

When click on pagination and go to page 2, and then click on page 1 to go back,
a 404 page is rendered.

<img width="652" alt="screen shot 2017-04-17 at 9 32 21 pm" src="https://cloud.githubusercontent.com/assets/8438980/25114875/fa5d0184-23b6-11e7-846e-f79855f34ca8.png">


**Expected**

The homepage should be rendered.

**Fix Justification**

When the pagination number 1 should be rendered, render the <a> tag href
attribute to be site.baseurl + '/'; in other words, render the index.html page